### PR TITLE
add product to order; check if open order

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,8 +9,8 @@ const routes = require('./routes/');
 let app = express();
 
 //middleware and routing
-app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 
 app.use('/api/v1/', routes);
 
@@ -22,7 +22,7 @@ app.use(function(req, res, next) {
 });
 
 app.use((err,req,res,next) => {
-    console.log("error", err);
+    console.log("error", err, "route", req.url);
     res.status(err.status || 500);
     res.json({
       message: err.message,

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -16,10 +16,18 @@ module.exports.getAllOrders = (req, res, next) => {
   });
 };
 
-module.exports.addNewOrder = ({body}, res, next) => {
-  Order.addOne(body)
-  .then(() => {
-    res.status(200).end();
+module.exports.postToOrder = ({body}, res, next) => {
+  Order.isOpenOrder(body.user_id)
+  .then( (order) => {
+    if (order) return Order.addToOpenOrder(order.order_id, body.product_id)
+    else Order.addOne(body).then( (lastID) => { return Order.addToOpenOrder(lastID, body.product_id)})
+  })
+  .then((lastID) => {
+    res.status(200).end("Product added to order"); //Experimenting with what to send back, if anything. Discuss.
+  })
+  .catch( (err) => {
+    console.log('error on order post', err);
+    next(err);
   });
 };
 

--- a/models/order.js
+++ b/models/order.js
@@ -23,13 +23,36 @@ const Order = {
     });
   },
   // method for adding an order
+  // accepts a req.body as oder param:
+  // {
+  //   "product_id": INT,
+  //   "user_id": INT
+  // }
   addOne: (order) => {
     return new Promise((resolve, reject) => {
-      db.run(`INSERT INTO orders VALUES(null, "${order.user_id}", "${order.payment_type_id}")`, (err) => {
+      db.run(`INSERT INTO orders VALUES(null, "${order.user_id}", null)`, function (err) {
         if(err) return reject(err);
-        resolve();
+        resolve(this.lastID);
       });
     })
+  },
+  // method for adding line item to orders_products join table
+  addToOpenOrder: (order_id, product_id) => {
+    return new Promise((resolve, reject) => {
+      db.run(`INSERT INTO orders_products values (null, ${order_id}, ${product_id})`, function(err) {
+        if (err) return reject(err);
+        resolve(this.lastID);
+      });
+    });
+  },
+  // check if a user already has an open order
+  isOpenOrder: (user_id) => {
+    return new Promise( (resolve, reject) => {
+      db.all(`SELECT * FROM orders WHERE user_id = ${user_id} AND payment_type_id is NULL`, (err, order) => {
+        if (err) return reject(err);
+        resolve(order.length ? order[0] : null);
+      });
+    });
   },
   // method for updating a order's info
   edit: (order) => {

--- a/routes/orders-route.js
+++ b/routes/orders-route.js
@@ -2,12 +2,12 @@
 
 const {Router} = require('express');
 const router = Router();
-const {getOneOrder, getAllOrders, addNewOrder, editOrder, deleteOrder} = require('../controllers/ordersCtrl');
+const {getOneOrder, getAllOrders, postToOrder, editOrder, deleteOrder} = require('../controllers/ordersCtrl');
 
-router.get('/order/:order_id', getOneOrder);
+router.get('/orders/:order_id', getOneOrder);
 router.get('/orders', getAllOrders);
-router.post('/order/new', addNewOrder);
-router.put('/order/edit', editOrder);
-router.delete('/order/delete/:order_id', deleteOrder);
+router.post('/orders', postToOrder);
+router.put('/orders/edit/:order_id', editOrder);
+router.delete('/orders/delete/:order_id', deleteOrder);
 
 module.exports = router;


### PR DESCRIPTION
Per https://github.com/TremendousPorcupines/bangazon-node-api/issues/38

Added ability to post a product to an order; Query handler ( orderCtrl.js ) receives a user_id and a product_id in req.body. It checks for an open order for that user_id with new Order method, `isOpenOrder`. If open order exists, the order_id and product_id are added directly to orders_products table with `addToOpenOrder` method. Otherwise, new order is created first with `addOne`, which now returns the new order_id via sqlite3's `this.lastID` property that is available in `db.run`'s callback method, and then `addToOpenOrder` is called by the request handler, and passes in `lastID` and the product_id from the req.body.

Not settled on what is proper to add to response after an add, other than a 200. We should discuss.