### PR TITLE
Gk open order data to null

### DIFF
--- a/db/faker/orders.js
+++ b/db/faker/orders.js
@@ -14,7 +14,6 @@ module.exports.generateOrders = () => {
       let types = data[1];
       let orders = [];
       let count = 0;
-      let total = 0;
 
       for (let i = 0; i < 200; i++) {
         let user_id;

--- a/db/faker/orders.js
+++ b/db/faker/orders.js
@@ -13,6 +13,8 @@ module.exports.generateOrders = () => {
       let users = data[0];
       let types = data[1];
       let orders = [];
+      let count = 0;
+      let total = 0;
 
       for (let i = 0; i < 200; i++) {
         let user_id;
@@ -25,8 +27,12 @@ module.exports.generateOrders = () => {
         }
 
         types.forEach((type) => {
-          if (user_id === type.user_id) {
-            payment_type_id = type.payment_type_id;
+          if (user_id === type.user_id && count++ % 6 != 0) {
+            if (count++ % 6 != 0) {
+              payment_type_id = type.payment_type_id;
+            } else {
+              payment_type_id = null;
+            }
           }
         })
 


### PR DESCRIPTION
This PR supports PR #39 and should be reviewed before approval of #39. It modifies the functionality for populating fake order data by creating null payment types for approximately 17% of orders populated. Null payment types will be need to test the methods written in #39.